### PR TITLE
FIXED warning for focusDepth on front-facing camera

### DIFF
--- a/ios/RN/RNCamera.m
+++ b/ios/RN/RNCamera.m
@@ -210,7 +210,7 @@ static NSDictionary *defaultFaceDetectorOptions = nil;
     AVCaptureDevice *device = [self.videoCaptureDeviceInput device];
     NSError *error = nil;
 
-    if (self.autoFocus < 0 || device.focusMode != RNCameraAutoFocusOff) {
+    if (self.autoFocus < 0 || device.focusMode != RNCameraAutoFocusOff || device.position == RNCameraTypeFront) {
         return;
     }
 


### PR DESCRIPTION
Fixes #1230

Adds an additional check to determine if the front-facing camera is active, allows for an early exit when changing focus depth