### PR TITLE
Relase camera on Android when pausing preview

### DIFF
--- a/android/src/main/java/com/google/android/cameraview/Camera1.java
+++ b/android/src/main/java/com/google/android/cameraview/Camera1.java
@@ -352,6 +352,9 @@ class Camera1 extends CameraViewImpl implements MediaRecorder.OnInfoListener,
             @Override
             public void run() {
                 synchronized(this){
+                    if(mCamera == null){
+                        start();
+                    }
                     mShowingPreview = true;
                     startCameraPreview();
                 }

--- a/android/src/main/java/com/google/android/cameraview/Camera1.java
+++ b/android/src/main/java/com/google/android/cameraview/Camera1.java
@@ -367,6 +367,7 @@ class Camera1 extends CameraViewImpl implements MediaRecorder.OnInfoListener,
 
             if(mCamera != null){
                 mCamera.stopPreview();
+                releaseCamera();
             }
         }
     }

--- a/android/src/main/java/com/google/android/cameraview/Camera1.java
+++ b/android/src/main/java/com/google/android/cameraview/Camera1.java
@@ -352,6 +352,9 @@ class Camera1 extends CameraViewImpl implements MediaRecorder.OnInfoListener,
             @Override
             public void run() {
                 synchronized(this){
+                    //if(mCamera == null){
+                    //    start();
+                    //}
                     mShowingPreview = true;
                     startCameraPreview();
                 }

--- a/android/src/main/java/com/google/android/cameraview/Camera1.java
+++ b/android/src/main/java/com/google/android/cameraview/Camera1.java
@@ -352,9 +352,6 @@ class Camera1 extends CameraViewImpl implements MediaRecorder.OnInfoListener,
             @Override
             public void run() {
                 synchronized(this){
-                    //if(mCamera == null){
-                    //    start();
-                    //}
                     mShowingPreview = true;
                     startCameraPreview();
                 }

--- a/android/src/main/java/org/reactnative/camera/CameraModule.java
+++ b/android/src/main/java/org/reactnative/camera/CameraModule.java
@@ -245,12 +245,7 @@ public class CameraModule extends ReactContextBaseJavaModule {
 
                 try {
                     cameraView = (RNCameraView) nativeViewHierarchyManager.resolveView(viewTag);
-                    if (cameraView.isCameraOpened()) {
-                        cameraView.resumePreview();
-                    } else {
-                        cameraView.start();
-                        cameraView.resumePreview();
-                    }
+                    cameraView.resumePreview();
                 } catch (Exception e) {
                     e.printStackTrace();
                 }

--- a/android/src/main/java/org/reactnative/camera/CameraModule.java
+++ b/android/src/main/java/org/reactnative/camera/CameraModule.java
@@ -247,6 +247,9 @@ public class CameraModule extends ReactContextBaseJavaModule {
                     cameraView = (RNCameraView) nativeViewHierarchyManager.resolveView(viewTag);
                     if (cameraView.isCameraOpened()) {
                         cameraView.resumePreview();
+                    } else {
+                        cameraView.start();
+                        cameraView.resumePreview();
                     }
                 } catch (Exception e) {
                     e.printStackTrace();


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect -->

# Summary
I am working on an application that requires both camera and nfc-access on the same screen, not simultaneously though. Certain Android phones however disable NFC-polling when camera is open due to NFC interfering with the camera. Background on this issue: https://stackoverflow.com/questions/34607168/nfc-unavailable-when-camera-is-open

This PR releases the camera so that NFC is free for use while the camera preview is paused.
<!--
Explain the **motivation** for making this change: here are some points to help you:

* What issues does the pull request solve? Please tag them so that they will get automatically closed once the PR is merged
* What is the feature? (if applicable)
* How did you implement the solution?
* What areas of the library does it impact?
-->

## Test Plan
Tested on simulator and Huawei P20 Pro.
While camera preview is on, NFC is unavailable. Calling pausePreview() releases camera, making NFC available.
Calling continuePreview() works as expected.

### What's required for testing (prerequisites)?
Android phone with NFC

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ❌     |
| Android |    ✅     |

## Checklist

<!-- Check completed item, when applicable, via: [X] -->

- [x ] I have tested this on a device and a simulator
- [ ] I added the documentation in `README.md`
- [ ] I mentioned this change in `CHANGELOG.md`
- [ ] I updated the typed files (TS and Flow)
- [ ] I added a sample use of the API in the example project (`example/App.js`)
