### PR TITLE
update exif dependency

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -72,7 +72,7 @@ dependencies {
   implementation "com.google.zxing:core:3.3.3"
   implementation "com.drewnoakes:metadata-extractor:2.11.0"
   generalImplementation "com.google.android.gms:play-services-vision:$googlePlayServicesVisionVersion"
-  implementation "androidx.exifinterface:exifinterface:1.0.0"
+  implementation "androidx.exifinterface:exifinterface:1.3.2"
   implementation "androidx.annotation:annotation:1.0.0"
   implementation "androidx.legacy:legacy-support-v4:1.0.0"
   mlkitImplementation "com.google.firebase:firebase-ml-vision:${safeExtGet('firebase-ml-vision', '19.0.3')}"


### PR DESCRIPTION
Upgrading Exifinterface from 1.1.0 to 1.3.2. No breaking changes expected, but just some overflow and memleaks fixes according to the logs (https://developer.android.com/jetpack/androidx/releases/exifinterface).

This is an attempt to fix some android devices corrupting images due to exif bugs, and also to bring it up to the same version as react-native-image-resizer, which works very well when combined with this library.

Related (https://github.com/bamlab/react-native-image-resizer/pull/273)