### PR TITLE
Remove exif thumbnail generation that may affect some devices.

### DIFF
--- a/android/src/main/java/com/google/android/cameraview/Camera1.java
+++ b/android/src/main/java/com/google/android/cameraview/Camera1.java
@@ -1122,6 +1122,13 @@ class Camera1 extends CameraViewImpl implements MediaRecorder.OnInfoListener,
         }
         mCameraParameters.setPreviewSize(size.getWidth(), size.getHeight());
         mCameraParameters.setPictureSize(pictureSize.getWidth(), pictureSize.getHeight());
+
+        // some android devices (mostly Samsung and high res devices)
+        // will include a JPEG thumbnail within the image's EXIF information
+        // This is not really appropriate for the library, and just increases the file size
+        // and has a chance of blowing up when `writeExif` is used
+        mCameraParameters.setJpegThumbnailSize(0, 0);
+
         if (mOrientation != Constants.ORIENTATION_AUTO) {
             mCameraParameters.setRotation(calcCameraRotation(orientationEnumToRotation(mOrientation)));
         } else {


### PR DESCRIPTION
Following the exif library upgrade, and after further debugging corrupted images, I've found out that some devices (especially samsung and high res camera ones) will include a thumbnail within the EXIF metadata.

This is somehow an erratic behaviour, as only some devices do this. However, if `writeExif` is used, it may cause either an out of memory error, or end up returning a massive base64 string to the JS side.

This update tries to standardize the behaviour, by not returning any thumbnail within the exif data.  Note that this may be a breaking change if anyone was relying on this, which is unlikely since the behaviour varied from device to device.