### PR TITLE
convert codec option to proper value in recordAsync()

### DIFF
--- a/src/RNCamera.js
+++ b/src/RNCamera.js
@@ -594,6 +594,12 @@ export default class Camera extends React.Component<PropsType, StateType> {
       }
     }
 
+    if (Platform.OS === 'ios') {
+      if (typeof options.codec === 'string') {
+        options.codec = Camera.Constants.VideoCodec[options.codec];
+      }
+    }
+
     if (__DEV__) {
       if (options.videoBitrate && typeof options.videoBitrate !== 'number') {
         // eslint-disable-next-line no-console

--- a/src/RNCamera.js
+++ b/src/RNCamera.js
@@ -518,19 +518,18 @@ export default class Camera extends React.Component<PropsType, StateType> {
     if (!options) {
       options = {};
     }
+
     if (!options.quality) {
       options.quality = 1;
     }
 
-    if (options.orientation) {
-      if (typeof options.orientation !== 'number') {
-        const { orientation } = options;
-        options.orientation = CameraManager.Orientation[orientation];
-        if (__DEV__) {
-          if (typeof options.orientation !== 'number') {
-            // eslint-disable-next-line no-console
-            console.warn(`Orientation '${orientation}' is invalid.`);
-          }
+    if (options.orientation && typeof options.orientation !== 'number') {
+      const { orientation } = options;
+      options.orientation = CameraManager.Orientation[orientation];
+      if (__DEV__) {
+        if (typeof options.orientation !== 'number') {
+          // eslint-disable-next-line no-console
+          console.warn(`Orientation '${orientation}' is invalid.`);
         }
       }
     }
@@ -578,11 +577,13 @@ export default class Camera extends React.Component<PropsType, StateType> {
   async recordAsync(options?: RecordingOptions) {
     if (!options || typeof options !== 'object') {
       options = {};
-    } else if (typeof options.quality === 'string') {
-      options.quality = Camera.Constants.VideoQuality[options.quality];
     }
-    if (options.orientation) {
-      if (typeof options.orientation !== 'number') {
+    else {
+      if (typeof options.quality === 'string') {
+        options.quality = Camera.Constants.VideoQuality[options.quality];
+      }
+
+      if (options.orientation && typeof options.orientation !== 'number') {
         const { orientation } = options;
         options.orientation = CameraManager.Orientation[orientation];
         if (__DEV__) {
@@ -592,18 +593,18 @@ export default class Camera extends React.Component<PropsType, StateType> {
           }
         }
       }
-    }
 
-    if (Platform.OS === 'ios') {
-      if (typeof options.codec === 'string') {
-        options.codec = Camera.Constants.VideoCodec[options.codec];
+      if (__DEV__) {
+        if (options.videoBitrate && typeof options.videoBitrate !== 'number') {
+          // eslint-disable-next-line no-console
+          console.warn('Video Bitrate should be a positive integer');
+        }
       }
-    }
 
-    if (__DEV__) {
-      if (options.videoBitrate && typeof options.videoBitrate !== 'number') {
-        // eslint-disable-next-line no-console
-        console.warn('Video Bitrate should be a positive integer');
+      if (Platform.OS === 'ios') {
+        if (typeof options.codec === 'string') {
+          options.codec = Camera.Constants.VideoCodec[options.codec];
+        }
       }
     }
 


### PR DESCRIPTION
`RecordOptions.codec` currently accepts string values such as 'H264', but when attempting to pass that option and value into `recordAsync()`, the following logs show up:
```
[native] Video Codec H264 is not available.
[javascript] Video Codec H264 is not available.
```

Turns out the codec option was being directly casted to AVVideoCodecType w/o first being converted from its string value.

**Environment:**
iPhone XS (iOS 14.4)