### PR TITLE
Improve hardware iOS orientation sensor usage.

### DIFF
--- a/ios/RN/RNCamera.m
+++ b/ios/RN/RNCamera.m
@@ -283,6 +283,7 @@ BOOL _sessionInterrupted = NO;
         // after mount to set the camera's default, and that will already
         // this method
         // [self initializeCaptureSessionInput];
+        [self.sensorOrientationChecker start];
         [self startSession];
     }
     else{
@@ -296,6 +297,7 @@ BOOL _sessionInterrupted = NO;
 
         [[NSNotificationCenter defaultCenter] removeObserver:self name:AVAudioSessionInterruptionNotification object:[AVAudioSession sharedInstance]];
 
+        [self.sensorOrientationChecker stop];
         [self stopSession];
     }
 
@@ -727,15 +729,17 @@ BOOL _sessionInterrupted = NO;
 }
 
 - (void)takePictureWithOrientation:(NSDictionary *)options resolve:(RCTPromiseResolveBlock)resolve reject:(RCTPromiseRejectBlock)reject{
-    [self.sensorOrientationChecker getDeviceOrientationWithBlock:^(UIInterfaceOrientation orientation) {
-        NSMutableDictionary *tmpOptions = [options mutableCopy];
-        if ([tmpOptions valueForKey:@"orientation"] == nil) {
-            tmpOptions[@"orientation"] = [NSNumber numberWithInteger:[self.sensorOrientationChecker convertToAVCaptureVideoOrientation:orientation]];
-        }
-        self.deviceOrientation = [NSNumber numberWithInteger:orientation];
-        self.orientation = [NSNumber numberWithInteger:[tmpOptions[@"orientation"] integerValue]];
-        [self takePicture:tmpOptions resolve:resolve reject:reject];
-    }];
+    
+    UIInterfaceOrientation orientation = [self.sensorOrientationChecker getDeviceOrientation];
+    
+    NSMutableDictionary *tmpOptions = [options mutableCopy];
+    
+    if ([tmpOptions valueForKey:@"orientation"] == nil) {
+        tmpOptions[@"orientation"] = [NSNumber numberWithInteger:[self.sensorOrientationChecker convertToAVCaptureVideoOrientation:orientation]];
+    }
+    self.deviceOrientation = [NSNumber numberWithInteger:orientation];
+    self.orientation = [NSNumber numberWithInteger:[tmpOptions[@"orientation"] integerValue]];
+    [self takePicture:tmpOptions resolve:resolve reject:reject];
 }
 
 - (void)takePicture:(NSDictionary *)options resolve:(RCTPromiseResolveBlock)resolve reject:(RCTPromiseRejectBlock)reject
@@ -919,7 +923,7 @@ BOOL _sessionInterrupted = NO;
                     }
 
                 }
-
+                
                 CFDictionaryRef finalMetaData = nil;
                 if (writeExif) {
                     finalMetaData = (__bridge CFDictionaryRef)metadata;
@@ -999,16 +1003,17 @@ BOOL _sessionInterrupted = NO;
 }
 
 - (void)recordWithOrientation:(NSDictionary *)options resolve:(RCTPromiseResolveBlock)resolve reject:(RCTPromiseRejectBlock)reject{
-    [self.sensorOrientationChecker getDeviceOrientationWithBlock:^(UIInterfaceOrientation orientation) {
-        NSMutableDictionary *tmpOptions = [options mutableCopy];
-        if ([tmpOptions valueForKey:@"orientation"] == nil) {
-            tmpOptions[@"orientation"] = [NSNumber numberWithInteger:[self.sensorOrientationChecker convertToAVCaptureVideoOrientation: orientation]];
-        }
-        self.deviceOrientation = [NSNumber numberWithInteger:orientation];
-        self.orientation = [NSNumber numberWithInteger:[tmpOptions[@"orientation"] integerValue]];
-        [self record:tmpOptions resolve:resolve reject:reject];
-    }];
+    
+    UIInterfaceOrientation orientation = [self.sensorOrientationChecker getDeviceOrientation];
+    NSMutableDictionary *tmpOptions = [options mutableCopy];
+    if ([tmpOptions valueForKey:@"orientation"] == nil) {
+        tmpOptions[@"orientation"] = [NSNumber numberWithInteger:[self.sensorOrientationChecker convertToAVCaptureVideoOrientation: orientation]];
+    }
+    self.deviceOrientation = [NSNumber numberWithInteger:orientation];
+    self.orientation = [NSNumber numberWithInteger:[tmpOptions[@"orientation"] integerValue]];
+    [self record:tmpOptions resolve:resolve reject:reject];
 }
+
 - (void)record:(NSDictionary *)options resolve:(RCTPromiseResolveBlock)resolve reject:(RCTPromiseRejectBlock)reject
 {
     if(self.videoCaptureDeviceInput == nil || !self.session.isRunning){

--- a/ios/RN/RNCamera.m
+++ b/ios/RN/RNCamera.m
@@ -326,7 +326,7 @@ BOOL _sessionInterrupted = NO;
 -(AVCaptureSessionPreset)getDefaultPreset
 {
     AVCaptureSessionPreset preset =
-    ([self pictureSize] && [[self pictureSize] integerValue] >= 0) ? [self pictureSize] : AVCaptureSessionPresetHigh;
+    ([self pictureSize] && [[self pictureSize] integerValue] >= 0) ? [self pictureSize] : AVCaptureSessionPresetPhoto;
 
     return preset;
 }

--- a/ios/RN/RNSensorOrientationChecker.h
+++ b/ios/RN/RNSensorOrientationChecker.h
@@ -9,13 +9,12 @@
 #import <UIKit/UIKit.h>
 #import <AVFoundation/AVFoundation.h>
 
-typedef void (^RNSensorCallback) (UIInterfaceOrientation orientation);
 
 @interface RNSensorOrientationChecker : NSObject
 
-@property (assign, nonatomic) UIInterfaceOrientation orientation;
-
-- (void)getDeviceOrientationWithBlock:(RNSensorCallback)callback;
+- (void) start;
+- (void) stop;
+- (UIInterfaceOrientation)getDeviceOrientation;
 - (AVCaptureVideoOrientation)convertToAVCaptureVideoOrientation:(UIInterfaceOrientation)orientation;
 
 @end

--- a/ios/RN/RNSensorOrientationChecker.m
+++ b/ios/RN/RNSensorOrientationChecker.m
@@ -13,7 +13,6 @@
 @interface RNSensorOrientationChecker ()
 
 @property (strong, nonatomic) CMMotionManager * motionManager;
-@property (strong, nonatomic) RNSensorCallback orientationCallback;
 
 @end
 
@@ -28,51 +27,31 @@
         self.motionManager.accelerometerUpdateInterval = 0.2;
         self.motionManager.gyroUpdateInterval = 0.2;
         self.motionManager.deviceMotionUpdateInterval = 0.2;
-        self.orientationCallback = nil;
     }
+    
+    
     return self;
 }
 
 - (void)dealloc
 {
-    [self pause];
+    [self stop];
 }
 
-- (void)resume
+- (void)start
 {
-    __weak __typeof(self) weakSelf = self;
-    [self.motionManager startDeviceMotionUpdatesToQueue:[NSOperationQueue new]
-                                             withHandler:^(CMDeviceMotion  *data, NSError *error) {
-                                                 if (!error) {
-                                                     self.orientation = [weakSelf getOrientationBy:data];
-                                                 }
-                                                 if (self.orientationCallback) {
-                                                     self.orientationCallback(self.orientation);
-                                                 }
-                                             }];
+    [self.motionManager startDeviceMotionUpdates];
 }
 
-- (void)pause
+- (void)stop
 {
     [self.motionManager stopDeviceMotionUpdates];
 }
 
-- (void)getDeviceOrientationWithBlock:(RNSensorCallback)callback
+- (UIInterfaceOrientation)getDeviceOrientation
 {
-    __weak __typeof(self) weakSelf = self;
-    self.orientationCallback = ^(UIInterfaceOrientation orientation) {
-        // Synchronized because this might fire more than once
-        // under some circumstances, causing a very bad loop
-        // to people that uses it.
-        @synchronized (weakSelf) {
-            if (callback && weakSelf.orientationCallback) {
-                callback(orientation);
-            }
-            weakSelf.orientationCallback = nil;
-            [weakSelf pause];
-        }
-    };
-    [self resume];
+    CMDeviceMotion* data = self.motionManager.deviceMotion;
+    return [self getOrientationBy:data];
 }
 
 - (UIInterfaceOrientation)getOrientationBy:(CMDeviceMotion*)motion
@@ -94,12 +73,6 @@
             return UIInterfaceOrientationPortrait;
         }
     }
-    
-//    __block UIInterfaceOrientation orientation;
-//    dispatch_sync(dispatch_get_main_queue(), ^{
-//        orientation = [[UIApplication sharedApplication] statusBarOrientation];
-//    });
-//    return orientation;
 }
 
 - (AVCaptureVideoOrientation)convertToAVCaptureVideoOrientation:(UIInterfaceOrientation)orientation

--- a/ios/RN/RNSensorOrientationChecker.m
+++ b/ios/RN/RNSensorOrientationChecker.m
@@ -27,6 +27,7 @@
         self.motionManager = [[CMMotionManager alloc] init];
         self.motionManager.accelerometerUpdateInterval = 0.2;
         self.motionManager.gyroUpdateInterval = 0.2;
+        self.motionManager.deviceMotionUpdateInterval = 0.2;
         self.orientationCallback = nil;
     }
     return self;


### PR DESCRIPTION
This PR improves how the physical device orientation and sensors are used in order to not rely on UI/Status bar orientation.

The rationale behind this change, is that for some reason accelerometer updates stops working when other native code also uses it. However, using `startDeviceMotionUpdatesToQueue` instead of accelerometer data, correctly coexists with other libraries.

Sensor data is now used while the camera is mounted, and orientation data is immediately available and doesn't need to be polled. Additionally, it does not use a custom queue to poll for sensor data, which fixes issues (for unknown reasons) when other native code uses motion sensors.

Also, revert photo preset change to Photo quality to restore high quality photos on iOS.