### PR TITLE
Ability to set video resolutions (videoFrameWidth & videoFrameHeight)

### DIFF
--- a/android/src/main/java/com/google/android/cameraview/Camera1.java
+++ b/android/src/main/java/com/google/android/cameraview/Camera1.java
@@ -1584,6 +1584,8 @@ class Camera1 extends CameraViewImpl implements MediaRecorder.OnInfoListener,
             camProfile = CamcorderProfile.get(mCameraId, CamcorderProfile.QUALITY_HIGH);
         }
         camProfile.videoBitRate = profile.videoBitRate;
+        camProfile.videoFrameWidth = profile.videoFrameWidth;
+        camProfile.videoFrameHeight = profile.videoFrameHeight;
         setCamcorderProfile(camProfile, recordAudio, fps);
 
         mMediaRecorder.setOrientationHint(calcCameraRotation(mOrientation != Constants.ORIENTATION_AUTO ? orientationEnumToRotation(mOrientation) : mDeviceOrientation));

--- a/android/src/main/java/com/google/android/cameraview/Camera2.java
+++ b/android/src/main/java/com/google/android/cameraview/Camera2.java
@@ -1400,6 +1400,8 @@ class Camera2 extends CameraViewImpl implements MediaRecorder.OnInfoListener, Me
             camProfile = CamcorderProfile.get(CamcorderProfile.QUALITY_HIGH);
         }
         camProfile.videoBitRate = profile.videoBitRate;
+        camProfile.videoFrameWidth = profile.videoFrameWidth;
+        camProfile.videoFrameHeight = profile.videoFrameHeight;
         setCamcorderProfile(camProfile, recordAudio);
 
         mMediaRecorder.setOrientationHint(getOutputRotation());

--- a/android/src/main/java/org/reactnative/camera/RNCameraView.java
+++ b/android/src/main/java/org/reactnative/camera/RNCameraView.java
@@ -311,6 +311,14 @@ public class RNCameraView extends CameraView implements LifecycleEventListener, 
             profile.videoBitRate = options.getInt("videoBitrate");
           }
 
+          if (options.hasKey("videoFrameWidth")) {
+            profile.videoFrameWidth = options.getInt("videoFrameWidth");
+          }
+
+          if (options.hasKey("videoFrameHeight")) {
+            profile.videoFrameHeight = options.getInt("videoFrameHeight");
+          }
+
           boolean recordAudio = true;
           if (options.hasKey("mute")) {
             recordAudio = !options.getBoolean("mute");

--- a/docs/RNCamera.md
+++ b/docs/RNCamera.md
@@ -718,6 +718,10 @@ Supported options:
 
 - `path` (file path on disk). Specifies the path on disk to record the video to. You can use the same `uri` returned to continue recording across start/stops
 
+- `videoFrameWidth` (number). Android only. The target video frame width in pixels. The target width should be supported by the device.
+
+- `videoFrameHeight` (number). Android only. The target video frame height in pixels. The target height should be supported by the device.
+
 The promise will be fulfilled with an object with some of the following properties:
 
 - `uri`: (string) the path to the video saved on your app's cache directory.

--- a/src/RNCamera.js
+++ b/src/RNCamera.js
@@ -232,6 +232,8 @@ type RecordingOptions = {
   mute?: boolean,
   path?: string,
   videoBitrate?: number,
+  videoFrameWidth?: number,
+  videoFrameHeight?: number,
 };
 
 type EventCallbackArgumentsType = {

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -454,6 +454,8 @@ interface RecordOptions {
   mirrorVideo?: boolean;
   path?: string;
   videoBitrate?: number;
+  videoFrameWidth?: number;
+  videoFrameHeight?: number;
 
   /** iOS only */
   codec?: keyof VideoCodec | VideoCodec[keyof VideoCodec];


### PR DESCRIPTION
It adds the ability to set `videoFrameWidth` and `videoFrameHeight`. 

**Test Plan**
Recorded two videos, 1 with the desired resolutions and other without setting them at all. 2nd test is it make sure that it still works as it used to previously.

# Test 1
`const video = await cameraRef.recordAsync({ mute: true, quality: '4:3', videoFrameWidth: 1280, videoFrameHeight: 960 });`

![image](https://user-images.githubusercontent.com/778391/108789584-90101400-7548-11eb-981b-8df5b938a74a.png)

# Test 2
`const video = await cameraRef.recordAsync({ mute: true, quality: '4:3' });`

![image](https://user-images.githubusercontent.com/778391/108789637-a4eca780-7548-11eb-8b9a-69ac36a548e6.png)


