### PR TITLE
Fixes a crash for devices that does not support bitrate setup.

### DIFF
--- a/ios/RN/RNCamera.m
+++ b/ios/RN/RNCamera.m
@@ -1166,9 +1166,18 @@ BOOL _sessionInterrupted = NO;
         if (options[@"codec"]) {
             if (@available(iOS 10, *)) {
                 AVVideoCodecType videoCodecType = options[@"codec"];
+                
                 if ([self.movieFileOutput.availableVideoCodecTypes containsObject:videoCodecType]) {
                     self.videoCodecType = videoCodecType;
-                    if(options[@"videoBitrate"]) {
+                    
+                    BOOL supportsBitRate = NO;
+                    
+                    // prevent crashing due to unsupported keys
+                    if (@available(iOS 12.0, *)) {
+                        supportsBitRate = [[self.movieFileOutput supportedOutputSettingsKeysForConnection:connection] containsObject:AVVideoCompressionPropertiesKey];
+                    }
+                    
+                    if(options[@"videoBitrate"] && supportsBitRate) {
                         NSString *videoBitrate = options[@"videoBitrate"];
                         [self.movieFileOutput setOutputSettings:@{
                           AVVideoCodecKey:videoCodecType,


### PR DESCRIPTION
Fixes the following crash when using bitrate config:

```
Hardware Model:     iPad7,1
Role:               Foreground
OS Version:         iOS 11.4


NSInvalidArgumentException: *** -[AVCaptureMovieFileOutput setOutputSettings:forConnection:] The only supported key is AVVideoCodecKey - the following keys are illegal: {(
    AVVideoCompressionPropertiesKey
)}
```

Additional docs (this property is in fact only supported on iOS >= 12)

```
On iOS, your outputSettings dictionary may only contain keys listed in - supportedOutputSettingsKeysForConnection:. If you specify any other key, an NSInvalidArgumentException will be thrown. Further restrictions may be imposed on the AVVideoCodecTypeKey. Its value should be present in the -availableVideoCodecTypes array. If AVVideoCompressionPropertiesKey is specified, you must also specify a valid value for AVVideoCodecKey. On iOS versions prior to 12.0, the only settable key for video connections is AVVideoCodecTypeKey. On iOS 12.0 and later, video connections gain support for AVVideoCompressionPropertiesKey.
```