### PR TITLE
Fix: iOS mirroring video always outputs low quality video

### DIFF
--- a/ios/RN/RNCamera.m
+++ b/ios/RN/RNCamera.m
@@ -1992,7 +1992,7 @@ BOOL _sessionInterrupted = NO;
     [videoComposition setInstructions:@[instruction]];
 
     // Export
-    AVAssetExportSession* exportSession = [AVAssetExportSession exportSessionWithAsset:videoAsset presetName:AVAssetExportPreset640x480];
+    AVAssetExportSession* exportSession = [AVAssetExportSession exportSessionWithAsset:videoAsset presetName:self.session.sessionPreset];
     NSString* filePath = [RNFileSystem generatePathInDirectory:[[RNFileSystem cacheDirectoryPath] stringByAppendingString:@"CameraFlip"] withExtension:@".mp4"];
     NSURL* outputURL = [NSURL fileURLWithPath:filePath];
     [exportSession setOutputURL:outputURL];

--- a/ios/RN/RNCamera.m
+++ b/ios/RN/RNCamera.m
@@ -1994,7 +1994,7 @@ BOOL _sessionInterrupted = NO;
     //reset preset to get current default
     AVCaptureSessionPreset preset = [self getDefaultPreset];
     if (self.session.sessionPreset != preset) {
-        [self updateSessionPreset: preset];
+        preset = self.session.sessionPreset;
     }
 
     // Export

--- a/ios/RN/RNCamera.m
+++ b/ios/RN/RNCamera.m
@@ -1991,7 +1991,7 @@ BOOL _sessionInterrupted = NO;
     [instruction setLayerInstructions:@[transformer]];
     [videoComposition setInstructions:@[instruction]];
     
-    //reset preset to get current default
+    //get preset for export via default or session
     AVCaptureSessionPreset preset = [self getDefaultPreset];
     if (self.session.sessionPreset != preset) {
         preset = self.session.sessionPreset;

--- a/ios/RN/RNCamera.m
+++ b/ios/RN/RNCamera.m
@@ -1990,9 +1990,15 @@ BOOL _sessionInterrupted = NO;
 
     [instruction setLayerInstructions:@[transformer]];
     [videoComposition setInstructions:@[instruction]];
+    
+    //reset preset to get current default
+    AVCaptureSessionPreset preset = [self getDefaultPreset];
+    if (self.session.sessionPreset != preset) {
+        [self updateSessionPreset: preset];
+    }
 
     // Export
-    AVAssetExportSession* exportSession = [AVAssetExportSession exportSessionWithAsset:videoAsset presetName:self.session.sessionPreset];
+    AVAssetExportSession* exportSession = [AVAssetExportSession exportSessionWithAsset:videoAsset presetName:preset];
     NSString* filePath = [RNFileSystem generatePathInDirectory:[[RNFileSystem cacheDirectoryPath] stringByAppendingString:@"CameraFlip"] withExtension:@".mp4"];
     NSURL* outputURL = [NSURL fileURLWithPath:filePath];
     [exportSession setOutputURL:outputURL];


### PR DESCRIPTION
Currently, using the prop `mirrorVideo` the mirrored output only delivers in 480 resolution. 

This PR configures the output from mirroring the camera output to align with the session-dictated AV preset, rather than hard-coding it.

