### PR TITLE
Fixed rect of interest issue

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -232,7 +232,7 @@ export interface RNCameraProps {
   onGoogleVisionBarcodesDetected?(event: GoogleVisionBarcodesDetectedEvent): void;
 
   // limiting scan area
-  rectOfInterest?: Point;
+  rectOfInterest?: RectOfInterest;
 
   // -- FACE DETECTION PROPS
 
@@ -291,6 +291,8 @@ interface Size<T = number> {
   width: T;
   height: T;
 }
+
+interface RectOfInterest extends Point,Size{}
 
 export interface Barcode {
   bounds: {


### PR DESCRIPTION
Rect of interest for typescript definition said that the rectOfInterest property is a Point. Point only has x and y, and rectOfInterest prop requires width and height also so I fixed the type definition