### PR TITLE
Feature/android camera2 fps

### DIFF
--- a/android/src/main/java/com/google/android/cameraview/Camera2.java
+++ b/android/src/main/java/com/google/android/cameraview/Camera2.java
@@ -40,6 +40,7 @@ import android.media.MediaRecorder;
 import android.media.MediaActionSound;
 import androidx.annotation.NonNull;
 import android.util.Log;
+import android.util.Range;
 import android.util.SparseIntArray;
 import android.view.Surface;
 import android.os.Handler;
@@ -380,9 +381,13 @@ class Camera2 extends CameraViewImpl implements MediaRecorder.OnInfoListener, Me
 
     @Override
     public ArrayList<int[]> getSupportedPreviewFpsRange() {
-        Log.e("CAMERA_2:: ", "getSupportedPreviewFpsRange is not currently supported for Camera2");
-        ArrayList<int[]> validValues = new ArrayList<int[]>();
-        return validValues;
+        ArrayList<int[]> fpsRanges = new ArrayList<int[]>();
+
+        for (Range<Integer> range : mCameraCharacteristics.get(CameraCharacteristics.CONTROL_AE_AVAILABLE_TARGET_FPS_RANGES)) {
+          fpsRanges.add(new int[]{range.getLower(), range.getUpper()});
+        }
+
+        return fpsRanges;
     }
 
     @Override

--- a/docs/API.md
+++ b/docs/API.md
@@ -30,9 +30,9 @@ title: Work in progress
 - [`pausePreview`](API.md#pausepreview)
 - [`resumePreview`](API.md#resumepreview)
 - [`getAvailablePictureSizes`](API.md#getavailablepicturesizes)
-- [`getSupportedRatiosAsync`](API.md#getsupportedratiosasync-android-only)
-- [`isRecording`](API.md#isrecording-ios-only)
-- [`getSupportedPreviewFpsRange`](API.md#getsupportedpreviewfpsrange-android-only)
+- [`getSupportedRatiosAsync`](API.md#getsupportedratiosasync---android-only)
+- [`isRecording`](API.md#isrecording---ios-only)
+- [`getSupportedPreviewFpsRange`](API.md#getsupportedpreviewfpsrange---android-only)
 
 ## Props
 
@@ -377,11 +377,14 @@ const isRecording = await isRecording();
 } */
 ```
 
-- [`getSupportedPreviewFpsRange`](API.md#getSupportedPreviewFpsRange`)
+---
 
 ## getSupportedPreviewFpsRange - Android only
 
-Android only. Returns a promise. The promise will be fulfilled with a json object including the fps ranges available for those devices ([android docs](<https://developer.android.com/reference/android/hardware/Camera.Parameters#getSupportedPreviewFpsRange()>))
+Android only. Returns a promise. The promise will be fulfilled with a json object including the fps ranges available for those devices.
+
+- [Camera1 API](<https://developer.android.com/reference/android/hardware/Camera.Parameters#getSupportedPreviewFpsRange()>)
+- [Camera2 API](https://developer.android.com/reference/android/hardware/camera2/CameraCharacteristics#CONTROL_AE_AVAILABLE_TARGET_FPS_RANGES)
 
 ### Method type
 

--- a/docs/RNCamera.md
+++ b/docs/RNCamera.md
@@ -405,6 +405,12 @@ For Android, this prop attempts to control the camera sensor capture resolution,
 
 For iOS, this prop controls the internal camera preset value and should rarely be changed. However, this value can be set to setup the sensor to match the video recording's quality in order to prevent flickering. The list of valid values can be gathered from https://developer.apple.com/documentation/avfoundation/avcapturesessionpreset and can also be requested with `getAvailablePictureSizes`.
 
+### `useCamera2Api`
+
+Values: boolean `true` | `false` (default) 
+
+Android only. Specifies whether to use Android's [Camera2 API](https://developer.android.com/reference/android/hardware/camera2/package-summary).
+
 ### Native Event callbacks props
 
 ### `onCameraReady`
@@ -689,14 +695,14 @@ Supported options:
     - `ios` Specifies capture settings suitable for CIF quality (352x288 pixel) video output.
     - `android` Not supported.
 
-- `videoBitrate`. (int greater than 0) This option specifies a desired video bitrate. For example, 5\*1000\*1000 would be 5Mbps.
+  If nothing is passed the device's highest camera quality will be used as default.
+
+- `videoBitrate` (int greater than 0). This option specifies a desired video bitrate. For example, 5\*1000\*1000 would be 5Mbps.
 
   - `ios` Supported however requires that the codec key is also set.
   - `android` Supported.
 
 - `orientation` (string or number). Specifies the orientation that us used for recording the video. Possible values: `"portrait"`, `"portraitUpsideDown"`, `"landscapeLeft"` or `"landscapeRight"`.
-
-  If nothing is passed the device's highest camera quality will be used as default.
 
 - `iOS` `codec`. This option specifies the codec of the output video. Setting the codec is only supported on `iOS >= 10`. The possible values are:
 


### PR DESCRIPTION
Adding Android Camera2 support for controlling fps through `recordAsync()`. The key for this to work was setting `CaptureRequest.CONTROL_AE_TARGET_FPS_RANGE`.

Along with this, I made an attempt at implementing `Camera2.getSupportedPreviewFpsRange()` by making it into a wrapper call around `mCameraCharacteristics.get(CameraCharacteristics.CONTROL_AE_AVAILABLE_TARGET_FPS_RANGES)`. I'm not sure if this is desired, and I mainly only did this for consistency reasons, so feel free to tell me to revert it.



