### PR TITLE
Fix: swapped fps min/max labels in getSupportedPreviewFpsRange() output

### DIFF
--- a/android/src/main/java/org/reactnative/camera/CameraModule.java
+++ b/android/src/main/java/org/reactnative/camera/CameraModule.java
@@ -481,8 +481,8 @@ public class CameraModule extends ReactContextBaseJavaModule {
                   ArrayList<int[]> ranges = cameraView.getSupportedPreviewFpsRange();
                   for (int[] range : ranges) {
                       WritableMap m = new WritableNativeMap();
-                      m.putInt("MAXIMUM_FPS", range[0]);
-                      m.putInt("MINIMUM_FPS", range[1]);
+                      m.putInt("MINIMUM_FPS", range[0]);
+                      m.putInt("MAXIMUM_FPS", range[1]);
                       result.pushMap(m);
                   }
                   promise.resolve(result);


### PR DESCRIPTION
Output in `getSupportedPreviewFpsRange()` is mixing up the “MINIMUM_FPS” and “MAXIMUM_FPS” labels.

e.g. Pixel 4: cameraType='front'

before:
```
[
  {
    “MINIMUM_FPS”: 15000,
    “MAXIMUM_FPS”: 15000
  },
  {
    “MINIMUM_FPS”: 30000,
    “MAXIMUM_FPS”: 15000
  },
  {
    “MINIMUM_FPS”: 30000,
    “MAXIMUM_FPS”: 30000
  }
]
```

after fix:
```
[
  {
    “MINIMUM_FPS”: 15000,
    “MAXIMUM_FPS”: 15000
  },
  {
    “MINIMUM_FPS”: 15000,
    “MAXIMUM_FPS”: 30000
  },
  {
    “MINIMUM_FPS”: 30000,
    “MAXIMUM_FPS”: 30000
  }
]
```