### PR TITLE
Use specified cameraId on record

### DIFF
--- a/android/src/main/java/org/reactnative/camera/RNCameraView.java
+++ b/android/src/main/java/org/reactnative/camera/RNCameraView.java
@@ -303,10 +303,16 @@ public class RNCameraView extends CameraView implements LifecycleEventListener, 
           int maxFileSize = options.hasKey("maxFileSize") ? options.getInt("maxFileSize") : -1;
           int fps = options.hasKey("fps") ? options.getInt("fps") : -1;
 
-          CamcorderProfile profile = CamcorderProfile.get(CamcorderProfile.QUALITY_HIGH);
-          if (options.hasKey("quality")) {
-            profile = RNCameraViewHelper.getCamcorderProfile(options.getInt("quality"));
+          int cameraId = -1;
+          if (!getCameraId().isEmpty()) {
+            cameraId = Integer.parseInt(getCameraId());
           }
+
+          CamcorderProfile profile = RNCameraViewHelper.getCamcorderProfile(cameraId, CamcorderProfile.QUALITY_HIGH);
+          if (options.hasKey("quality")) {
+            profile = RNCameraViewHelper.getCamcorderProfile(cameraId, options.getInt("quality"));
+          }
+
           if (options.hasKey("videoBitrate")) {
             profile.videoBitRate = options.getInt("videoBitrate");
           }

--- a/android/src/main/java/org/reactnative/camera/RNCameraViewHelper.java
+++ b/android/src/main/java/org/reactnative/camera/RNCameraViewHelper.java
@@ -381,6 +381,21 @@ public class RNCameraViewHelper {
     return profile;
   }
 
+  public static CamcorderProfile getCamcorderProfile(int cameraId, int quality) {
+    if (cameraId < 0) {
+      return getCamcorderProfile(quality);
+    }
+    CamcorderProfile profile = CamcorderProfile.get(cameraId, CamcorderProfile.QUALITY_HIGH);
+    int camcorderQuality = getCamcorderProfileQualityFromCameraModuleConstant(quality);
+    if (CamcorderProfile.hasProfile(cameraId, camcorderQuality)) {
+      profile = CamcorderProfile.get(cameraId, camcorderQuality);
+      if (quality == CameraModule.VIDEO_4x3) {
+        profile.videoFrameWidth = 640;
+      }
+    }
+    return profile;
+  }
+
   public static WritableMap getExifData(ExifInterface exifInterface) {
     WritableMap exifMap = Arguments.createMap();
     for (String[] tagInfo : exifTags) {


### PR DESCRIPTION
Right now, on Android library ignores the specified camera ID set via prop `cameraId` on record start. It creates `CamcorderProfile` without specifying camera ID and that leads to exception on devices with only one front-facing camera (e.g. Chromebook). See: #2933, #2805. This PR takes into consideration the camera ID on creation of CamcorderProfile. 