### PR TITLE
Add links to alternative libraries

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [Looking for Maintainers](https://github.com/react-native-community/react-native-camera/issues/3000)
 
-We are looking for maintainers for this package, or to deprecated this in favor of expo-camera, it nobody want to maintain this
+We are looking for maintainers for this package, or to deprecated this in favor of [react-native-vision-camera](https://github.com/mrousavy/react-native-vision-camera) or [expo-camera](https://docs.expo.io/versions/latest/sdk/camera/), it nobody want to maintain this
 
 ## Docs
 Follow our docs here [https://react-native-camera.github.io/react-native-camera/](https://react-native-camera.github.io/react-native-camera/)


### PR DESCRIPTION
Adds links to [VisionCamera](https://github.com/mrousavy/react-native-vision-camera) and expo-camera to the README as alternatives to react-native-camera.

Why VisionCamera? See this discussion: [💡 Replacement for react-native-camera](https://github.com/mrousavy/react-native-vision-camera/discussions/134) (especially [this comment](https://github.com/mrousavy/react-native-vision-camera/discussions/134#discussioncomment-935288))

VisionCamera also features an extensible Frame Processor API to run QR code scanning, facial recognition, etc. straight from JS which is powered by JSI 🚀 