### PR TITLE
Bugfix [iOS]: isRecordingInterrupted is not being set to `true` when it should

### DIFF
--- a/ios/RN/RNCamera.m
+++ b/ios/RN/RNCamera.m
@@ -1893,6 +1893,10 @@ BOOL _sessionInterrupted = NO;
         if (value) {
             success = [value boolValue];
         }
+        // Check if the recording stopped due to the session being interrupted.
+        if ([error code] == AVErrorSessionWasInterrupted) {
+          self.isRecordingInterrupted = YES;
+        }
     }
     if (success && self.videoRecordedResolve != nil) {
         NSMutableDictionary *result = [[NSMutableDictionary alloc] init];


### PR DESCRIPTION
I was encountering unexpected behavior in iOS where if I call `recordAsync()` and then minimize or navigate away from the app during the recording, `isRecordingInterrupted` will still return as `false`. Meanwhile, testing the same scenario in Android produces `true` as expected.

It would seem like this condition is already being handled via an event handler (`sessionWasInterrupted`). However, I found that whenever a session is interrupted, the recording automatically stops and propagates `isRecordingInterrupted` before the event handler has a chance to make the intended update.

To fix this, I make use of captureOutput's `error` param, which provides the following info whenever a recording is stopped due to an interrupted session:
```
Domain=AVFoundationErrorDomain
Code=-11818 "Recording Stopped"
UserInfo={
  AVErrorRecordingSuccessfullyFinishedKey=true,
  NSLocalizedDescription=Recording Stopped,
  NSLocalizedRecoverySuggestion=Stop any other actions using the recording device and try again.,
  AVErrorRecordingFailureDomainKey=1,
  NSUnderlyingError=0x2819d2850 {Error Domain=NSOSStatusErrorDomain Code=-16414 "(null)"}
}
```