### PR TITLE
Workaround for hardware JPEG rotation bug on some Samsung devices

### DIFF
--- a/android/src/main/java/com/google/android/cameraview/Camera1.java
+++ b/android/src/main/java/com/google/android/cameraview/Camera1.java
@@ -52,7 +52,7 @@ class Camera1 extends CameraViewImpl implements MediaRecorder.OnInfoListener,
 
     private static final SparseArrayCompat<String> FLASH_MODES = new SparseArrayCompat<>();
 
-    private static final String[] BROKEN_ROTATION_DEVICE_MODELS = {"SM-G532M", "SM-T813"};
+    private static final String[] BROKEN_ROTATION_DEVICE_MODELS = {"SM-G532M", "SM-T813", "SM-T307U", "SM-T713"};
 
     static {
         FLASH_MODES.put(Constants.FLASH_OFF, Camera.Parameters.FLASH_MODE_OFF);

--- a/android/src/main/java/com/google/android/cameraview/Camera1.java
+++ b/android/src/main/java/com/google/android/cameraview/Camera1.java
@@ -179,12 +179,11 @@ class Camera1 extends CameraViewImpl implements MediaRecorder.OnInfoListener,
                         // and we might need to re-create it and restart the camera
                         surfaceWasDestroyed = true;
 
-                        try{
+                        try {
                             mCamera.setPreviewCallback(null);
                             // note: this might give a debug message that can be ignored.
                             mCamera.setPreviewDisplay(null);
-                        }
-                        catch(Exception e){
+                        } catch (Exception e) {
                             Log.e("CAMERA_1::", "onSurfaceDestroyed preview cleanup failed", e);
                         }
                     }
@@ -266,18 +265,16 @@ class Camera1 extends CameraViewImpl implements MediaRecorder.OnInfoListener,
         // or host destroyed. Should avoid crashes with concurrent calls
         synchronized(this){
             if (mMediaRecorder != null) {
-                try{
+                try {
                     mMediaRecorder.stop();
-                }
-                catch(RuntimeException e){
+                } catch (RuntimeException e) {
                     Log.e("CAMERA_1::", "mMediaRecorder.stop() failed", e);
                 }
 
-                try{
+                try {
                     mMediaRecorder.reset();
                     mMediaRecorder.release();
-                }
-                catch(RuntimeException e){
+                } catch (RuntimeException e) {
                     Log.e("CAMERA_1::", "mMediaRecorder.release() failed", e);
                 }
 
@@ -293,11 +290,10 @@ class Camera1 extends CameraViewImpl implements MediaRecorder.OnInfoListener,
 
             if (mCamera != null) {
                 mIsPreviewActive = false;
-                try{
+                try {
                     mCamera.stopPreview();
                     mCamera.setPreviewCallback(null);
-                }
-                catch(Exception e){
+                } catch (Exception e) {
                     Log.e("CAMERA_1::", "stop preview cleanup failed", e);
                 }
             }
@@ -337,14 +333,13 @@ class Camera1 extends CameraViewImpl implements MediaRecorder.OnInfoListener,
     private void startCameraPreview() {
         // only start the preview if we didn't yet.
         if(!mIsPreviewActive && mCamera != null){
-            try{
+            try {
                 mIsPreviewActive = true;
                 mCamera.startPreview();
                 if (mIsScanning) {
                     mCamera.setPreviewCallback(this);
                 }
-            }
-            catch(Exception e){
+            } catch (Exception e) {
                 mIsPreviewActive = false;
                 Log.e("CAMERA_1::", "startCameraPreview failed", e);
             }
@@ -566,12 +561,11 @@ class Camera1 extends CameraViewImpl implements MediaRecorder.OnInfoListener,
         }
         synchronized(this){
             if (setAutoFocusInternal(autoFocus)) {
-                try{
+                try {
                     if(mCamera != null){
                         mCamera.setParameters(mCameraParameters);
                     }
-                }
-                catch(RuntimeException e ) {
+                } catch (RuntimeException e) {
                     Log.e("CAMERA_1::", "setParameters failed", e);
                 }
             }
@@ -593,12 +587,12 @@ class Camera1 extends CameraViewImpl implements MediaRecorder.OnInfoListener,
             return;
         }
         if (setFlashInternal(flash)) {
-            try{
+            try {
                 if(mCamera != null){
                     mCamera.setParameters(mCameraParameters);
                 }
             }
-            catch(RuntimeException e ) {
+            catch (RuntimeException e) {
                 Log.e("CAMERA_1::", "setParameters failed", e);
             }
         }
@@ -621,12 +615,11 @@ class Camera1 extends CameraViewImpl implements MediaRecorder.OnInfoListener,
             return;
         }
         if (setExposureInternal(exposure)) {
-            try{
+            try {
                 if(mCamera != null){
                     mCamera.setParameters(mCameraParameters);
                 }
-            }
-            catch(RuntimeException e ) {
+            } catch (RuntimeException e) {
                 Log.e("CAMERA_1::", "setParameters failed", e);
             }
         }
@@ -649,12 +642,11 @@ class Camera1 extends CameraViewImpl implements MediaRecorder.OnInfoListener,
             return;
         }
         if (setZoomInternal(zoom)) {
-            try{
+            try {
                 if(mCamera != null){
                     mCamera.setParameters(mCameraParameters);
                 }
-            }
-            catch(RuntimeException e ) {
+            } catch (RuntimeException e ) {
                 Log.e("CAMERA_1::", "setParameters failed", e);
             }
         }
@@ -672,12 +664,11 @@ class Camera1 extends CameraViewImpl implements MediaRecorder.OnInfoListener,
             return;
         }
         if (setWhiteBalanceInternal(whiteBalance)) {
-            try{
+            try {
                 if(mCamera != null){
                     mCamera.setParameters(mCameraParameters);
                 }
-            }
-            catch(RuntimeException e ) {
+            } catch (RuntimeException e) {
                 Log.e("CAMERA_1::", "setParameters failed", e);
             }
         }
@@ -756,15 +747,14 @@ class Camera1 extends CameraViewImpl implements MediaRecorder.OnInfoListener,
         // if not capturing already, atomically set it to true
         if (!mIsRecording.get() && isPictureCaptureInProgress.compareAndSet(false, true)) {
 
-            try{
+            try {
                 if (options.hasKey("orientation") && options.getInt("orientation") != Constants.ORIENTATION_AUTO) {
                     mOrientation = options.getInt("orientation");
                     int rotation = orientationEnumToRotation(mOrientation);
                     mCameraParameters.setRotation(calcCameraRotation(rotation));
-                    try{
+                    try {
                         mCamera.setParameters(mCameraParameters);
-                    }
-                    catch(RuntimeException e ) {
+                    } catch (RuntimeException e) {
                         Log.e("CAMERA_1::", "setParameters rotation failed", e);
                     }
                 }
@@ -774,10 +764,9 @@ class Camera1 extends CameraViewImpl implements MediaRecorder.OnInfoListener,
                 if (requestedRotation != 0 && fallbackToSoftwareRotation()) {
                     softwareRotation = requestedRotation;
                     mCameraParameters.setRotation(0);
-                    try{
+                    try {
                         mCamera.setParameters(mCameraParameters);
-                    }
-                    catch(RuntimeException e ) {
+                    } catch (RuntimeException e) {
                         Log.e("CAMERA_1::", "setParameters 0 rotation failed", e);
                     }
                 } else {
@@ -788,10 +777,9 @@ class Camera1 extends CameraViewImpl implements MediaRecorder.OnInfoListener,
                 // This also achieves a much faster JPEG compression speed since it's done on the hardware
                 if(options.hasKey("quality")){
                     mCameraParameters.setJpegQuality((int) (options.getDouble("quality") * 100));
-                    try{
+                    try {
                         mCamera.setParameters(mCameraParameters);
-                    }
-                    catch(RuntimeException e ) {
+                    } catch (RuntimeException e) {
                         Log.e("CAMERA_1::", "setParameters quality failed", e);
                     }
                 }
@@ -813,23 +801,21 @@ class Camera1 extends CameraViewImpl implements MediaRecorder.OnInfoListener,
                         synchronized(Camera1.this){
                             if(mCamera != null){
                                 if (options.hasKey("pauseAfterCapture") && !options.getBoolean("pauseAfterCapture")) {
-                                    try{
+                                    try {
                                         mCamera.startPreview();
                                         mIsPreviewActive = true;
                                         if (mIsScanning) {
                                             mCamera.setPreviewCallback(Camera1.this);
                                         }
-                                    }
-                                    catch(Exception e){
+                                    } catch (Exception e) {
                                         mIsPreviewActive = false;
                                         mCamera.setPreviewCallback(null);
                                         Log.e("CAMERA_1::", "camera startPreview failed", e);
                                     }
                                 } else {
-                                    try{
+                                    try {
                                         mCamera.stopPreview();
-                                    }
-                                    catch(Exception e){
+                                    } catch (Exception e) {
                                         Log.e("CAMERA_1::", "camera stopPreview failed", e);
                                     }
                                     mIsPreviewActive = false;
@@ -848,13 +834,11 @@ class Camera1 extends CameraViewImpl implements MediaRecorder.OnInfoListener,
                         }
                     }
                 });
-            }
-            catch(Exception e){
+            } catch (Exception e) {
                 isPictureCaptureInProgress.set(false);
                 throw e;
             }
-        }
-        else{
+        } else {
             throw new IllegalStateException("Camera capture failed. Camera is already capturing.");
         }
     }
@@ -878,7 +862,7 @@ class Camera1 extends CameraViewImpl implements MediaRecorder.OnInfoListener,
                 // This should also be safe to call since both recording and
                 // camera parameters are getting set by the same thread and process.
                 // https://stackoverflow.com/a/14855668/1777914
-                try{
+                try {
                     mCamera.setParameters(mCameraParameters);
                 } catch (Exception e) {
                     Log.e("CAMERA_1::", "Record setParameters failed", e);
@@ -943,10 +927,9 @@ class Camera1 extends CameraViewImpl implements MediaRecorder.OnInfoListener,
                     mIsPreviewActive = false;
                 }
 
-                try{
+                try {
                     mCamera.setDisplayOrientation(calcDisplayOrientation(displayOrientation));
-                }
-                catch(RuntimeException e ) {
+                } catch (RuntimeException e) {
                     Log.e("CAMERA_1::", "setDisplayOrientation failed", e);
                 }
                 if (needsToStopPreview) {
@@ -964,11 +947,10 @@ class Camera1 extends CameraViewImpl implements MediaRecorder.OnInfoListener,
             }
             mDeviceOrientation = deviceOrientation;
             if (isCameraOpened() && mOrientation == Constants.ORIENTATION_AUTO && !mIsRecording.get() && !isPictureCaptureInProgress.get()) {
-                try{
+                try {
                     mCameraParameters.setRotation(calcCameraRotation(deviceOrientation));
                     mCamera.setParameters(mCameraParameters);
-                }
-                catch(RuntimeException e ) {
+                } catch (RuntimeException e) {
                     Log.e("CAMERA_1::", "setParameters failed", e);
                 }
             }
@@ -981,7 +963,7 @@ class Camera1 extends CameraViewImpl implements MediaRecorder.OnInfoListener,
         mBgHandler.post(new Runnable() {
             @Override
             public void run() {
-                try{
+                try {
                     if (mCamera == null) {
                         mPreviewTexture = surfaceTexture;
                         return;
@@ -1017,7 +999,7 @@ class Camera1 extends CameraViewImpl implements MediaRecorder.OnInfoListener,
     private void chooseCamera() {
         if(_mCameraId == null || _mCameraId.isEmpty()){
 
-            try{
+            try {
                 int count = Camera.getNumberOfCameras();
                 if(count == 0){
                     //throw new RuntimeException("No camera available.");
@@ -1040,17 +1022,15 @@ class Camera1 extends CameraViewImpl implements MediaRecorder.OnInfoListener,
             // getCameraInfo may fail if hardware is unavailable
             // and crash the whole app. Return INVALID_CAMERA_ID
             // which will in turn fire a mount error event
-            catch(Exception e){
+            catch (Exception e){
                 Log.e("CAMERA_1::", "chooseCamera failed.", e);
                 mCameraId = INVALID_CAMERA_ID;
             }
-        }
-        else{
-            try{
+        } else {
+            try {
                 mCameraId = Integer.parseInt(_mCameraId);
                 Camera.getCameraInfo(mCameraId, mCameraInfo);
-            }
-            catch(Exception e){
+            } catch (Exception e) {
                 mCameraId = INVALID_CAMERA_ID;
             }
         }
@@ -1064,7 +1044,7 @@ class Camera1 extends CameraViewImpl implements MediaRecorder.OnInfoListener,
         // in case we got an invalid camera ID
         // due to no cameras or invalid ID provided,
         // return false so we can raise a mount error
-        if(mCameraId == INVALID_CAMERA_ID){
+        if (mCameraId == INVALID_CAMERA_ID) {
             return false;
         }
 
@@ -1106,11 +1086,12 @@ class Camera1 extends CameraViewImpl implements MediaRecorder.OnInfoListener,
             // try to release it before returning an error
             // in order to avoid erratic behaviour
             // Both getParameters and open may return null
-            try{
+            try {
                 mCamera.release();
                 mCamera = null;
+            } catch (RuntimeException e2) {
+                // pass
             }
-            catch(RuntimeException e2){}
 
             return false;
         }
@@ -1187,10 +1168,9 @@ class Camera1 extends CameraViewImpl implements MediaRecorder.OnInfoListener,
         setScanningInternal(mIsScanning);
         setPlaySoundInternal(mPlaySoundOnCapture);
 
-        try{
+        try {
             mCamera.setParameters(mCameraParameters);
-        }
-        catch(RuntimeException e ) {
+        } catch (RuntimeException e) {
             Log.e("CAMERA_1::", "setParameters failed", e);
         }
         if (needsToStopPreview) {
@@ -1270,22 +1250,20 @@ class Camera1 extends CameraViewImpl implements MediaRecorder.OnInfoListener,
                             if (!parameters.getSupportedFocusModes().contains(Camera.Parameters.FOCUS_MODE_AUTO)) {
                                 return; //cannot autoFocus
                             }
-                            try{
+                            try {
                                 mCamera.setParameters(parameters);
-                            }
-                            catch(RuntimeException e ) {
+                            } catch (RuntimeException e) {
                                 Log.e("CAMERA_1::", "setParameters failed", e);
                             }
 
-                            try{
+                            try {
                                 mCamera.autoFocus(new Camera.AutoFocusCallback() {
                                     @Override
                                     public void onAutoFocus(boolean success, Camera camera) {
                                         //resetFocus(success, camera);
                                     }
                                 });
-                            }
-                            catch(RuntimeException e ) {
+                            } catch (RuntimeException e) {
                                 Log.e("CAMERA_1::", "autoFocus failed", e);
                             }
                         } else if (parameters.getMaxNumMeteringAreas() > 0) {
@@ -1296,34 +1274,31 @@ class Camera1 extends CameraViewImpl implements MediaRecorder.OnInfoListener,
                             parameters.setFocusAreas(meteringAreas);
                             parameters.setMeteringAreas(meteringAreas);
 
-                            try{
+                            try {
                                 mCamera.setParameters(parameters);
-                            }
-                            catch(RuntimeException e ) {
+                            } catch (RuntimeException e) {
                                 Log.e("CAMERA_1::", "setParameters failed", e);
                             }
 
-                            try{
+                            try {
                                 mCamera.autoFocus(new Camera.AutoFocusCallback() {
                                     @Override
                                     public void onAutoFocus(boolean success, Camera camera) {
                                         //resetFocus(success, camera);
                                     }
                                 });
-                            }
-                            catch(RuntimeException e ) {
+                            } catch (RuntimeException e) {
                                 Log.e("CAMERA_1::", "autoFocus failed", e);
                             }
                         } else {
-                            try{
+                            try {
                                 mCamera.autoFocus(new Camera.AutoFocusCallback() {
                                     @Override
                                     public void onAutoFocus(boolean success, Camera camera) {
                                         //mCamera.cancelAutoFocus();
                                     }
                                 });
-                            }
-                            catch(RuntimeException e ) {
+                            } catch (RuntimeException e) {
                                 Log.e("CAMERA_1::", "autoFocus failed", e);
                             }
                         }
@@ -1350,10 +1325,9 @@ class Camera1 extends CameraViewImpl implements MediaRecorder.OnInfoListener,
                         parameters.setFocusMode(Camera.Parameters.FOCUS_MODE_CONTINUOUS_PICTURE);
                         parameters.setFocusAreas(null);
                         parameters.setMeteringAreas(null);
-                        try{
+                        try {
                           mCamera.setParameters(parameters);
-                        }
-                        catch(RuntimeException e ) {
+                        } catch (RuntimeException e) {
                           Log.e("CAMERA_1::", "setParameters failed", e);
                         }
                     }
@@ -1556,7 +1530,7 @@ class Camera1 extends CameraViewImpl implements MediaRecorder.OnInfoListener,
     private void setPlaySoundInternal(boolean playSoundOnCapture){
         mPlaySoundOnCapture = playSoundOnCapture;
         if(mCamera != null){
-            try{
+            try {
                 // Always disable shutter sound, and play our own.
                 // This is because not all devices honor this value when set to true
                 boolean res = mCamera.enableShutterSound(false);
@@ -1568,8 +1542,7 @@ class Camera1 extends CameraViewImpl implements MediaRecorder.OnInfoListener,
                 if(!res){
                     mPlaySoundOnCapture = false;
                 }
-            }
-            catch(Exception ex){
+            } catch (Exception ex) {
                 Log.e("CAMERA_1::", "setPlaySoundInternal failed", ex);
                 mPlaySoundOnCapture = false;
             }
@@ -1653,7 +1626,7 @@ class Camera1 extends CameraViewImpl implements MediaRecorder.OnInfoListener,
                     Log.e("CAMERA_1::", "stopMediaRecorder stop failed", ex);
                 }
 
-                try{
+                try {
                     mMediaRecorder.reset();
                     mMediaRecorder.release();
                 } catch (RuntimeException ex) {

--- a/android/src/main/java/com/google/android/cameraview/Camera1.java
+++ b/android/src/main/java/com/google/android/cameraview/Camera1.java
@@ -52,7 +52,7 @@ class Camera1 extends CameraViewImpl implements MediaRecorder.OnInfoListener,
 
     private static final SparseArrayCompat<String> FLASH_MODES = new SparseArrayCompat<>();
 
-    private static final String[] BROKEN_ROTATION_DEVICE_MODELS = {"SM-G532M", "SM-T813", "SM-T307U", "SM-T713"};
+    private static final String[] BROKEN_ROTATION_DEVICE_MODELS = {"SM-G532M", "SM-T813", "SM-T819", "SM-T307U", "SM-T713"};
 
     static {
         FLASH_MODES.put(Constants.FLASH_OFF, Camera.Parameters.FLASH_MODE_OFF);

--- a/android/src/main/java/com/google/android/cameraview/Camera2.java
+++ b/android/src/main/java/com/google/android/cameraview/Camera2.java
@@ -195,7 +195,7 @@ class Camera2 extends CameraViewImpl implements MediaRecorder.OnInfoListener, Me
                     buffer.get(data);
                     if (image.getFormat() == ImageFormat.JPEG) {
                         // @TODO: implement deviceOrientation
-                        mCallback.onPictureTaken(data, 0);
+                        mCallback.onPictureTaken(data, 0, 0);
                     } else {
                         mCallback.onFramePreview(data, image.getWidth(), image.getHeight(), mDisplayOrientation);
                     }

--- a/android/src/main/java/com/google/android/cameraview/CameraView.java
+++ b/android/src/main/java/com/google/android/cameraview/CameraView.java
@@ -705,9 +705,9 @@ public class CameraView extends FrameLayout {
         }
 
         @Override
-        public void onPictureTaken(byte[] data, int deviceOrientation) {
+        public void onPictureTaken(byte[] data, int deviceOrientation, int softwareRotation) {
             for (Callback callback : mCallbacks) {
-                callback.onPictureTaken(CameraView.this, data, deviceOrientation);
+                callback.onPictureTaken(CameraView.this, data, deviceOrientation, softwareRotation);
             }
         }
 
@@ -864,7 +864,7 @@ public class CameraView extends FrameLayout {
          * @param cameraView The associated {@link CameraView}.
          * @param data       JPEG data.
          */
-        public void onPictureTaken(CameraView cameraView, byte[] data, int deviceOrientation) {}
+        public void onPictureTaken(CameraView cameraView, byte[] data, int deviceOrientation, int softwareRotation) {}
 
         /**
          * Called when a video recording starts

--- a/android/src/main/java/com/google/android/cameraview/CameraViewImpl.java
+++ b/android/src/main/java/com/google/android/cameraview/CameraViewImpl.java
@@ -157,7 +157,7 @@ abstract class CameraViewImpl {
 
         void onCameraClosed();
 
-        void onPictureTaken(byte[] data, int deviceOrientation);
+        void onPictureTaken(byte[] data, int deviceOrientation, int softwareRotation);
 
         void onVideoRecorded(String path, int videoOrientation, int deviceOrientation);
 

--- a/android/src/main/java/org/reactnative/camera/RNCameraView.java
+++ b/android/src/main/java/org/reactnative/camera/RNCameraView.java
@@ -109,7 +109,7 @@ public class RNCameraView extends CameraView implements LifecycleEventListener, 
       }
 
       @Override
-      public void onPictureTaken(CameraView cameraView, final byte[] data, int deviceOrientation) {
+      public void onPictureTaken(CameraView cameraView, final byte[] data, int deviceOrientation, int softwareRotation) {
         Promise promise = mPictureTakenPromises.poll();
         ReadableMap options = mPictureTakenOptions.remove(promise);
         if (options.hasKey("fastMode") && options.getBoolean("fastMode")) {
@@ -117,10 +117,10 @@ public class RNCameraView extends CameraView implements LifecycleEventListener, 
         }
         final File cacheDirectory = mPictureTakenDirectories.remove(promise);
         if(Build.VERSION.SDK_INT >= 11/*HONEYCOMB*/) {
-          new ResolveTakenPictureAsyncTask(data, promise, options, cacheDirectory, deviceOrientation, RNCameraView.this)
+          new ResolveTakenPictureAsyncTask(data, promise, options, cacheDirectory, deviceOrientation, softwareRotation, RNCameraView.this)
                   .executeOnExecutor(AsyncTask.THREAD_POOL_EXECUTOR);
         } else {
-          new ResolveTakenPictureAsyncTask(data, promise, options, cacheDirectory, deviceOrientation, RNCameraView.this)
+          new ResolveTakenPictureAsyncTask(data, promise, options, cacheDirectory, deviceOrientation, softwareRotation, RNCameraView.this)
                   .execute();
         }
         RNCameraViewHelper.emitPictureTakenEvent(cameraView);

--- a/android/src/main/java/org/reactnative/camera/tasks/ResolveTakenPictureAsyncTask.java
+++ b/android/src/main/java/org/reactnative/camera/tasks/ResolveTakenPictureAsyncTask.java
@@ -15,7 +15,6 @@ import org.reactnative.camera.utils.RNFileUtils;
 import com.facebook.react.bridge.Arguments;
 import com.facebook.react.bridge.Promise;
 import com.facebook.react.bridge.ReadableMap;
-import com.facebook.react.bridge.ReadableType;
 import com.facebook.react.bridge.WritableMap;
 
 import java.io.ByteArrayInputStream;
@@ -32,14 +31,16 @@ public class ResolveTakenPictureAsyncTask extends AsyncTask<Void, Void, Writable
     private ReadableMap mOptions;
     private File mCacheDirectory;
     private int mDeviceOrientation;
+    private int mSoftwareRotation;
     private PictureSavedDelegate mPictureSavedDelegate;
 
-    public ResolveTakenPictureAsyncTask(byte[] imageData, Promise promise, ReadableMap options, File cacheDirectory, int deviceOrientation, PictureSavedDelegate delegate) {
+    public ResolveTakenPictureAsyncTask(byte[] imageData, Promise promise, ReadableMap options, File cacheDirectory, int deviceOrientation, int softwareRotation, PictureSavedDelegate delegate) {
         mPromise = promise;
         mOptions = options;
         mImageData = imageData;
         mCacheDirectory = cacheDirectory;
         mDeviceOrientation = deviceOrientation;
+        mSoftwareRotation = softwareRotation;
         mPictureSavedDelegate = delegate;
     }
 
@@ -65,7 +66,7 @@ public class ResolveTakenPictureAsyncTask extends AsyncTask<Void, Void, Writable
         WritableMap exifData = null;
         ReadableMap exifExtraData = null;
 
-        boolean orientationChanged = false;
+        boolean exifOrientationFixed = false;
 
         response.putInt("deviceOrientation", mDeviceOrientation);
         response.putInt("pictureOrientation", mOptions.hasKey("orientation") ? mOptions.getInt("orientation") : mDeviceOrientation);
@@ -77,22 +78,26 @@ public class ResolveTakenPictureAsyncTask extends AsyncTask<Void, Void, Writable
             // and this behaves more like the iOS version.
             // We will load all data lazily only when needed.
 
-            // this should not incurr in any overhead if not read/used
+            // this should not incur in any overhead if not read/used
             inputStream = new ByteArrayInputStream(mImageData);
 
+            if (mSoftwareRotation != 0) {
+                loadBitmap();
+                mBitmap = rotateBitmap(mBitmap, mSoftwareRotation);
+            } else {
+                // Rotate the bitmap to the proper orientation if requested
+                if(mOptions.hasKey("fixOrientation") && mOptions.getBoolean("fixOrientation")){
+                    exifInterface = new ExifInterface(inputStream);
 
-            // Rotate the bitmap to the proper orientation if requested
-            if(mOptions.hasKey("fixOrientation") && mOptions.getBoolean("fixOrientation")){
+                    // Get orientation of the image from mImageData via inputStream
+                    int orientation = exifInterface.getAttributeInt(ExifInterface.TAG_ORIENTATION, ExifInterface.ORIENTATION_UNDEFINED);
 
-                exifInterface = new ExifInterface(inputStream);
-
-                // Get orientation of the image from mImageData via inputStream
-                int orientation = exifInterface.getAttributeInt(ExifInterface.TAG_ORIENTATION, ExifInterface.ORIENTATION_UNDEFINED);
-
-                if(orientation != ExifInterface.ORIENTATION_UNDEFINED){
-                    loadBitmap();
-                    mBitmap = rotateBitmap(mBitmap, getImageRotation(orientation));
-                    orientationChanged = true;
+                    if(orientation != ExifInterface.ORIENTATION_UNDEFINED && getImageRotation(orientation) != 0) {
+                        loadBitmap();
+                        int angle = getImageRotation(orientation);
+                        mBitmap = rotateBitmap(mBitmap, angle);
+                        exifOrientationFixed = true;
+                    }
                 }
             }
 
@@ -148,7 +153,7 @@ public class ResolveTakenPictureAsyncTask extends AsyncTask<Void, Void, Writable
                     exifData.putInt("width", mBitmap.getWidth());
                     exifData.putInt("height", mBitmap.getHeight());
 
-                    if(orientationChanged){
+                    if(exifOrientationFixed){
                         exifData.putInt(ExifInterface.TAG_ORIENTATION, ExifInterface.ORIENTATION_NORMAL);
                     }
                 }
@@ -166,7 +171,6 @@ public class ResolveTakenPictureAsyncTask extends AsyncTask<Void, Void, Writable
             // final processing
             // Based on whether or not we loaded the full bitmap into memory, final processing differs
             if(mBitmap == null){
-
                 // set response dimensions. If we haven't read our bitmap, get it efficiently
                 // without loading the actual bitmap into memory
                 BitmapFactory.Options options = new BitmapFactory.Options();
@@ -220,15 +224,16 @@ public class ResolveTakenPictureAsyncTask extends AsyncTask<Void, Void, Writable
 
             }
             else{
-
                 // get response dimensions right from the bitmap if we have it
                 response.putInt("width", mBitmap.getWidth());
                 response.putInt("height", mBitmap.getHeight());
 
                 // Cache compressed image in imageStream
                 ByteArrayOutputStream imageStream = new ByteArrayOutputStream();
-                mBitmap.compress(Bitmap.CompressFormat.JPEG, getQuality(), imageStream);
-
+                if (!mBitmap.compress(Bitmap.CompressFormat.JPEG, getQuality(), imageStream)) {
+                    mPromise.reject(ERROR_TAG, "Could not compress image to JPEG");
+                    return null;
+                }
 
                 // Write compressed image to file in cache directory unless otherwise specified
                 if (!mOptions.hasKey("doNotSave") || !mOptions.getBoolean("doNotSave")) {
@@ -322,22 +327,22 @@ public class ResolveTakenPictureAsyncTask extends AsyncTask<Void, Void, Writable
         return RNFileUtils.getOutputFilePath(mCacheDirectory, ".jpg");
     }
 
-    private String writeStreamToFile(ByteArrayOutputStream inputStream) throws IOException {
+    private String writeStreamToFile(ByteArrayOutputStream imageDataStream) throws IOException {
         String outputPath = null;
         IOException exception = null;
-        FileOutputStream outputStream = null;
+        FileOutputStream fileOutputStream = null;
 
         try {
             outputPath = getImagePath();
-            outputStream = new FileOutputStream(outputPath);
-            inputStream.writeTo(outputStream);
+            fileOutputStream = new FileOutputStream(outputPath);
+            imageDataStream.writeTo(fileOutputStream);
         } catch (IOException e) {
             e.printStackTrace();
             exception = e;
         } finally {
             try {
-                if (outputStream != null) {
-                    outputStream.close();
+                if (fileOutputStream != null) {
+                    fileOutputStream.close();
                 }
             } catch (IOException e) {
                 e.printStackTrace();

--- a/android/src/main/java/org/reactnative/camera/tasks/ResolveTakenPictureAsyncTask.java
+++ b/android/src/main/java/org/reactnative/camera/tasks/ResolveTakenPictureAsyncTask.java
@@ -84,20 +84,20 @@ public class ResolveTakenPictureAsyncTask extends AsyncTask<Void, Void, Writable
             if (mSoftwareRotation != 0) {
                 loadBitmap();
                 mBitmap = rotateBitmap(mBitmap, mSoftwareRotation);
-            } else {
-                // Rotate the bitmap to the proper orientation if requested
-                if(mOptions.hasKey("fixOrientation") && mOptions.getBoolean("fixOrientation")){
-                    exifInterface = new ExifInterface(inputStream);
+            }
 
-                    // Get orientation of the image from mImageData via inputStream
-                    int orientation = exifInterface.getAttributeInt(ExifInterface.TAG_ORIENTATION, ExifInterface.ORIENTATION_UNDEFINED);
+            // Rotate the bitmap to the proper orientation if requested
+            if(mOptions.hasKey("fixOrientation") && mOptions.getBoolean("fixOrientation")){
+                exifInterface = new ExifInterface(inputStream);
 
-                    if(orientation != ExifInterface.ORIENTATION_UNDEFINED && getImageRotation(orientation) != 0) {
-                        loadBitmap();
-                        int angle = getImageRotation(orientation);
-                        mBitmap = rotateBitmap(mBitmap, angle);
-                        exifOrientationFixed = true;
-                    }
+                // Get orientation of the image from mImageData via inputStream
+                int orientation = exifInterface.getAttributeInt(ExifInterface.TAG_ORIENTATION, ExifInterface.ORIENTATION_UNDEFINED);
+
+                if(orientation != ExifInterface.ORIENTATION_UNDEFINED && getImageRotation(orientation) != 0) {
+                    loadBitmap();
+                    int angle = getImageRotation(orientation);
+                    mBitmap = rotateBitmap(mBitmap, angle);
+                    exifOrientationFixed = true;
                 }
             }
 


### PR DESCRIPTION
### Description

This PR implements a workaround to avoid this issue: https://github.com/react-native-camera/react-native-camera/issues/3060

### What is the root cause

Android's `Camera.PictureCallback::onPictureTaken(byte[] data, Camera camera)` is returning a corrupted file. The byte[] data array is full of 0x00 after a few kB of data. This happens when mCameraParameters.setRotation(...) is set to any rotation besides 0 on our Galaxy Tab S2 9.7 Wi-Fi SM-T813.

### What is the workaround / fix 

The facilities in `ResolveTakenPictureAsyncTask.java` can handle the rotation in software. The workaround is to set `mCameraParameters.setRotation(0)`, take the picture, and perform the rotation in the async task. To differentiate this "backup" rotation from the rotation performed when "fixOrientation" is set, a new parameter `softwareRotation` has been added to `ResolveTakenPictureAsyncTask`.

The `softwareRotation` is only used for the known affected devices, set in `BROKEN_ROTATION_DEVICE_MODELS`. Other devices will continue to use hardware rotation (which is probably faster).

### How to test

If you don't have an affected device on hand, you can still test this alternate implementation by changing `Camera1::fallbackToSoftwareRotation()` to return true or add your test device model to `BROKEN_ROTATION_DEVICE_MODELS`.

### What can be improved

I only added "SM-G532M" and "SM-T813" which we know have this problem. More devices are probably affected. Since it seems to always be Samsung devices, we could enable this alternate rotation mode for all of them.