### PR TITLE
implement onCameraReady event on Windows

### DIFF
--- a/src/RNCamera.js
+++ b/src/RNCamera.js
@@ -848,7 +848,7 @@ export default class Camera extends React.Component<PropsType, StateType> {
             style={StyleSheet.absoluteFill}
             ref={this._setReference}
             onMountError={this._onMountError}
-            onCameraReady={this._onCameraReady}
+            onCameraReady={this._onObjectDetected(this._onCameraReady)}
             onAudioInterrupted={this._onAudioInterrupted}
             onAudioConnected={this._onAudioConnected}
             onGoogleVisionBarcodesDetected={this._onObjectDetected(

--- a/windows/ReactNativeCameraCPP/ReactCameraConstants.h
+++ b/windows/ReactNativeCameraCPP/ReactCameraConstants.h
@@ -8,6 +8,7 @@
 #include "JSValue.h"
 
 #define BarcodeReadEvent L"onBarCodeRead"
+#define CameraReadyEvent L"onCameraReady"
 
 namespace winrt::ReactNativeCameraCPP {
 class ReactCameraConstants {

--- a/windows/ReactNativeCameraCPP/ReactCameraView.cpp
+++ b/windows/ReactNativeCameraCPP/ReactCameraView.cpp
@@ -714,6 +714,12 @@ IAsyncAction ReactCameraView::InitializeAsync() {
           });
 
       m_isInitialized = true;
+
+      auto control = this->get_strong().try_as<winrt::FrameworkElement>();
+      if (m_reactContext && control) {
+        m_reactContext.DispatchEvent(control, CameraReadyEvent, null);
+      }
+
     }
   } catch (winrt::hresult_error const &) {
     m_isInitialized = false;

--- a/windows/ReactNativeCameraCPP/ReactCameraView.cpp
+++ b/windows/ReactNativeCameraCPP/ReactCameraView.cpp
@@ -717,7 +717,7 @@ IAsyncAction ReactCameraView::InitializeAsync() {
 
       auto control = this->get_strong().try_as<winrt::FrameworkElement>();
       if (m_reactContext && control) {
-        m_reactContext.DispatchEvent(control, CameraReadyEvent, null);
+        m_reactContext.DispatchEvent(control, CameraReadyEvent, nullptr);
       }
 
     }

--- a/windows/ReactNativeCameraCPP/ReactCameraViewManager.cpp
+++ b/windows/ReactNativeCameraCPP/ReactCameraViewManager.cpp
@@ -89,6 +89,11 @@ ConstantProviderDelegate ReactCameraViewManager::ExportedCustomDirectEventTypeCo
     constantWriter.WriteObjectBegin();
     WriteProperty(constantWriter, L"registrationName", BarcodeReadEvent);
     constantWriter.WriteObjectEnd();
+
+    constantWriter.WritePropertyName(CameraReadyEvent);
+    constantWriter.WriteObjectBegin();
+    WriteProperty(constantWriter, L"registrationName", CameraReadyEvent);
+    constantWriter.WriteObjectEnd();
   };
 }
 


### PR DESCRIPTION
when repeatedly clicking to flip front/back cameras, the app would crash.  noticed that some docs/examples relied on the onCameraReady event to prevent this.  however, this was not implemented for Windows.