### PR TITLE
default variable to empty string to match RN props

### DIFF
--- a/android/src/main/java/com/google/android/cameraview/Camera1.java
+++ b/android/src/main/java/com/google/android/cameraview/Camera1.java
@@ -80,7 +80,7 @@ class Camera1 extends CameraViewImpl implements MediaRecorder.OnInfoListener,
     private Handler mHandler = new Handler();
 
     private int mCameraId;
-    private String _mCameraId;
+    private String _mCameraId = "";
 
     private final AtomicBoolean isPictureCaptureInProgress = new AtomicBoolean(false);
 

--- a/android/src/main/java/com/google/android/cameraview/Camera2.java
+++ b/android/src/main/java/com/google/android/cameraview/Camera2.java
@@ -208,7 +208,7 @@ class Camera2 extends CameraViewImpl implements MediaRecorder.OnInfoListener, Me
 
 
     private String mCameraId;
-    private String _mCameraId;
+    private String _mCameraId = "";
 
     private CameraCharacteristics mCameraCharacteristics;
 


### PR DESCRIPTION
This prevents a double call to `setCameraId` as JS side sets the default id to `''`. Under some cases, it may prevent the camera from stopping and starting again if it was already started before the default prop made effect.

Prop default value: https://github.com/react-native-camera/react-native-camera/blob/master/src/RNCamera.js#L462

Distinct check on the native side that will always fire due to JS/Native default prop value mismatch: https://github.com/react-native-camera/react-native-camera/blob/master/android/src/main/java/com/google/android/cameraview/Camera1.java#L402