### PR TITLE
Android null checks if camera is not ready

### DIFF
--- a/android/src/main/java/com/google/android/cameraview/Camera1.java
+++ b/android/src/main/java/com/google/android/cameraview/Camera1.java
@@ -1412,7 +1412,7 @@ class Camera1 extends CameraViewImpl implements MediaRecorder.OnInfoListener,
      */
     private boolean setAutoFocusInternal(boolean autoFocus) {
         mAutoFocus = autoFocus;
-        if (isCameraOpened()) {
+        if (isCameraOpened() && mCameraParameters != null) {
             final List<String> modes = mCameraParameters.getSupportedFocusModes();
             if (autoFocus && modes.contains(Camera.Parameters.FOCUS_MODE_CONTINUOUS_PICTURE)) {
                 mCameraParameters.setFocusMode(Camera.Parameters.FOCUS_MODE_CONTINUOUS_PICTURE);
@@ -1435,7 +1435,7 @@ class Camera1 extends CameraViewImpl implements MediaRecorder.OnInfoListener,
      * @return {@code true} if {@link #mCameraParameters} was modified.
      */
     private boolean setFlashInternal(int flash) {
-        if (isCameraOpened()) {
+        if (isCameraOpened() && mCameraParameters != null) {
             List<String> modes = mCameraParameters.getSupportedFlashModes();
             String mode = FLASH_MODES.get(flash);
             if(modes == null) {
@@ -1460,7 +1460,7 @@ class Camera1 extends CameraViewImpl implements MediaRecorder.OnInfoListener,
 
     private boolean setExposureInternal(float exposure) {
         mExposure = exposure;
-        if (isCameraOpened()){
+        if (isCameraOpened() && mCameraParameters != null){
             int minExposure = mCameraParameters.getMinExposureCompensation();
             int maxExposure = mCameraParameters.getMaxExposureCompensation();
 
@@ -1482,7 +1482,8 @@ class Camera1 extends CameraViewImpl implements MediaRecorder.OnInfoListener,
      * @return {@code true} if {@link #mCameraParameters} was modified.
      */
     private boolean setZoomInternal(float zoom) {
-        if (isCameraOpened() && mCameraParameters.isZoomSupported()) {
+        if (isCameraOpened() && mCameraParameters != null &&
+                mCameraParameters.isZoomSupported()) {
             int maxZoom = mCameraParameters.getMaxZoom();
             int scaledValue = (int) (zoom * maxZoom);
             mCameraParameters.setZoom(scaledValue);
@@ -1499,7 +1500,7 @@ class Camera1 extends CameraViewImpl implements MediaRecorder.OnInfoListener,
      */
     private boolean setWhiteBalanceInternal(int whiteBalance) {
         mWhiteBalance = whiteBalance;
-        if (isCameraOpened()) {
+        if (isCameraOpened() && mCameraParameters != null) {
             final List<String> modes = mCameraParameters.getSupportedWhiteBalance();
             String mode = WB_MODES.get(whiteBalance);
             if (modes != null && modes.contains(mode)) {


### PR DESCRIPTION
Not sure why this happens, possibly a race condition, but I've just got this crash due to a null pointer exception when certain props are set on the camera. A null check should help prevent the crash.

```
Caused by: java.lang.NullPointerException: Attempt to invoke virtual method 'boolean android.hardware.Camera$Parameters.isZoomSupported()' on a null object reference
        at com.google.android.cameraview.Camera1.setZoomInternal(Camera1.java:1485)
        at com.google.android.cameraview.Camera1.setZoom(Camera1.java:645)
        at com.google.android.cameraview.CameraView.setZoom(CameraView.java:586)
        at org.reactnative.camera.CameraViewManager.setZoom(CameraViewManager.java:121)
        at java.lang.reflect.Method.invoke(Method.java:-2)
        at com.facebook.react.uimanager.ViewManagersPropertyCache$PropSetter.updateViewProp(ViewManagersPropertyCache.java:87)
```